### PR TITLE
Time indexing bug fix in wiggle plotting function

### DIFF
--- a/rfpy/plotting.py
+++ b/rfpy/plotting.py
@@ -86,7 +86,7 @@ def wiggle(stream1, stream2=None, sort=None, tmin=0., tmax=30, normalize=True,
         ntr = len(stream1)
         maxamp = np.median(
             [np.max(np.abs(
-                tr.data[time > tmin and time < tmax])) for tr in stream1])
+                tr.data[(time > tmin) & (time < tmax)])) for tr in stream1])
 
     f = plt.figure()
 


### PR DESCRIPTION
Calling plotting.wiggle produces `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()` on line 89. `and` evaluates the truth value of the entire array object, which is not well-defined, so I changed it to a bitwise `&`, which makes boolean evaluations on the values of the time index arrays rather than the arrays themselves.