### PR TITLE
Increase harmonic processing speed with numba

### DIFF
--- a/docs/rfpy.rst
+++ b/docs/rfpy.rst
@@ -654,6 +654,12 @@ Or, alternatively,
 
     >>> harmonics.dcomp_find_azim()
 
+To use `numba` compiler to increase speed,
+
+.. sourcecode:: python
+
+    >>> harmonics.dcomp_find_azim(use_numba=True)
+
 In either case the harmonic components are available as an attribute of type
 :class:`~obspy.core.Stream` (``harmonics.hstream``) and, if available, the azimuth
 of the dominant direction (``harmonics.azim``). 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -578,6 +578,8 @@ Usage
                          set]
       --save             Set this option to save the Harmonics object to a pickled
                          file. [Default does not save object]
+      --use-numba        Use numba jit to increase processing speed
+                         [Default does not use numba]
 
     Settings for plotting results:
       Specify parameters for plotting the back-azimuth harmonics.

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -324,11 +324,18 @@ to 10 seconds (to avoid the large zero-lag pulse):
 
 .. note::
 
-    Warning!! This command is particularly slow, especially for large data sets.
+    Warning!! This command is particularly slow, especially for large data sets. The speed can
+    be increase by using ``--use-numba`` argument.
 
 .. code-block::
 
     $ rfpy_harmonics --no-outlier --find-azim --trange=2.,10. MMPY.pkl
+
+To increase the processing speed use ``--use_numba`` to utilize ``numba`` just-in-time compiler:
+
+.. code-block::
+
+    $ rfpy_harmonics  --use_numba --no-outlier --find-azim --trange=2.,10. MMPY.pkl
 
     ################################################################################
     #        __                 _                                      _           #

--- a/rfpy/harmonics.py
+++ b/rfpy/harmonics.py
@@ -136,8 +136,6 @@ class Harmonics(object):
             Variance of the 5 harmonics between ``xmin`` and ``xmax``
 
         """
-        import time
-        t0 = time.time()
 
         if not xmin:
             xmin = self.xmin
@@ -259,9 +257,6 @@ class Harmonics(object):
         self.hstream = Stream(traces=[A, B1, B2, C1, C2])
         self.azim = indaz*daz
         self.var = [C0var, C1var, C2var, C3var, C4var]
-
-        t1 = time.time()
-        print("Elapsed time ", t1-t0)
 
     @staticmethod
     @numba.jit(nopython=True, nogil=True)

--- a/rfpy/harmonics.py
+++ b/rfpy/harmonics.py
@@ -30,6 +30,7 @@ from obspy.core import Stream, Trace
 import matplotlib.pyplot as plt
 import numba
 from numba_progress import ProgressBar
+from tqdm import trange
 
 
 class Harmonics(object):
@@ -168,7 +169,7 @@ class Harmonics(object):
             C3 = np.zeros((nz, naz))
             C4 = np.zeros((nz, naz))
             # Loop over each depth step
-            for iz in range(nz):
+            for iz in trange(nz, ascii=True):
 
                 # Build matrices OBS and H for each azimuth
                 for iaz in range(naz):

--- a/rfpy/harmonics.py
+++ b/rfpy/harmonics.py
@@ -108,16 +108,7 @@ class Harmonics(object):
         self.xmin = xmin
         self.xmax = xmax
 
-    @staticmethod
-    @numba.jit(nopython=True, nogil=True)
-    def _dcomp_find_azim_numba(
-        progress_proxy=None,
-        xmin=None, xmax=None,
-        nbin=None, nz=None, delta=None,
-        baz_list=None,
-        dataR_list=None,
-        dataT_list=None,
-    ):
+    def dcomp_find_azim(self, xmin=None, xmax=None, use_numba=False):
         """
         Method to decompose radial and transverse receiver function
         streams into back-azimuth harmonics and determine the main
@@ -130,165 +121,8 @@ class Harmonics(object):
             Minimum x axis value over which to calculate ``azim``
         xmax : float
             Maximum x axis value over which to calculate ``azim``
-
-        Attributes
-        ----------
-        hstream : :class:`~obspy.core.Stream`
-            Stream containing the 5 harmonics, oriented in direction ``azim``
-        azim : float
-            Direction (azimuth) along which the B1 component of the stream
-            is minimized (between ``xmin`` and ``xmax``)
-        var : :class:`~numpy.ndarray`
-            Variance of the 5 harmonics between ``xmin`` and ``xmax``
-
-        """
-
-        
-
-        # Some integers
-        nbin = nbin
-        nz = nz
-        naz = 180
-        daz = np.float(360/naz)
-        deg2rad = np.pi/180.
-
-        # Define depth range over which to calculate azimuth
-        indmin = int(xmin/delta)
-        indmax = int(xmax/delta)
-
-        # Initialize work arrays
-        C0 = np.zeros((nz, naz))
-        C1 = np.zeros((nz, naz))
-        C2 = np.zeros((nz, naz))
-        C3 = np.zeros((nz, naz))
-        C4 = np.zeros((nz, naz))
-
-        # Loop over each depth step
-        for iz in range(nz):
-
-            # Build matrices OBS and H for each azimuth
-            for iaz in range(naz):
-
-                # Initialize work arrays
-                OBS = np.zeros(2*nbin)
-                H = np.zeros((2*nbin, 5))
-
-                azim = iaz*daz
-
-                # Radial component
-                for irow, dataR, baz in zip(range(len(dataR_list)),dataR_list,baz_list):
-
-                    baz = baz
-                    OBS[irow] = dataR[iz]
-                    H[irow, 0] = 1.0
-                    H[irow, 1] = np.cos(deg2rad*(baz-azim))
-                    H[irow, 2] = np.sin(deg2rad*(baz-azim))
-                    H[irow, 3] = np.cos(2.*deg2rad*(baz-azim))
-                    H[irow, 4] = np.sin(2.*deg2rad*(baz-azim))
-
-                shift = 90.
-
-                # Transverse component
-                for irow, dataT, baz in zip(range(len(dataT_list)),dataT_list,baz_list):
-
-                    baz = baz
-                    OBS[irow+nbin] = dataT[iz]
-                    H[irow+nbin, 0] = 0.0
-                    H[irow+nbin, 1] = np.cos(deg2rad*(baz+shift-azim))
-                    H[irow+nbin, 2] = np.sin(deg2rad*(baz+shift-azim))
-                    H[irow+nbin, 3] = np.cos(2.*deg2rad*(baz+shift/2.0-azim))
-                    H[irow+nbin, 4] = np.sin(2.*deg2rad*(baz+shift/2.0-azim))
-
-                # Solve system of equations with truncated SVD
-                u, s, v = np.linalg.svd(H)
-                s[s < 0.001] = 0.
-                CC = np.linalg.solve(s.reshape(s.shape[0],1) * v, u.T.dot(OBS)[:5])
-
-                # Fill up arrays
-                C0[iz, iaz] = np.float(CC[0])
-                C1[iz, iaz] = np.float(CC[1])
-                C2[iz, iaz] = np.float(CC[2])
-                C3[iz, iaz] = np.float(CC[3])
-                C4[iz, iaz] = np.float(CC[4])
-
-            progress_proxy.update(1)
-
-        # Minimize variance of third component over specific depth range to
-        # find azim
-        C1var = np.zeros(naz)
-        for iaz in range(naz):
-            C1var[iaz] = np.sqrt(np.mean(np.square(C1[indmin:indmax, iaz])))
-        indaz = np.argmin(C1var)
-
-        C0var = np.sqrt(np.mean(np.square(C0[indmin:indmax, indaz])))
-        C1var = np.sqrt(np.mean(np.square(C1[indmin:indmax, indaz])))
-        C2var = np.sqrt(np.mean(np.square(C2[indmin:indmax, indaz])))
-        C3var = np.sqrt(np.mean(np.square(C3[indmin:indmax, indaz])))
-        C4var = np.sqrt(np.mean(np.square(C4[indmin:indmax, indaz])))
-
-        return C0,C1,C2,C3,C4,C0var,C1var,C2var,C3var,C4var,indaz,daz
-
-    def dcomp_find_azim_numba(self, xmin=None, xmax=None):
-
-        print()
-        print('Decomposing receiver functions into baz harmonics')
-
-        import time
-        t0 = time.time()
-
-        if not xmin:
-            xmin = self.xmin
-        if not xmax:
-            xmax = self.xmax
-
-        str_stats = self.radialRF[0].stats
-        baz_list = np.array([trace0.stats.baz for trace0 in self.radialRF])
-        dataR_list = np.array([trace0.data for trace0 in self.radialRF])
-        dataT_list = np.array([trace0.data for trace0 in self.transvRF])
-        with ProgressBar(total=len(self.radialRF[0].data), ascii=" #") as progress:
-            C0,C1,C2,C3,C4,C0var,C1var,C2var,C3var,C4var,indaz,daz = self._dcomp_find_azim_numba(
-                xmin=xmin, xmax=xmax,
-                nbin=len(self.radialRF),
-                nz=len(self.radialRF[0].data),
-                delta=self.radialRF[0].stats.delta,
-                baz_list=baz_list,
-                dataR_list=dataR_list,
-                dataT_list=dataT_list,
-                progress_proxy=progress
-            )
-
-        # Put back into traces
-        A = Trace(data=C0[:, indaz], header=str_stats)
-        B1 = Trace(data=C1[:, indaz], header=str_stats)
-        B2 = Trace(data=C2[:, indaz], header=str_stats)
-        C1 = Trace(data=C3[:, indaz], header=str_stats)
-        C2 = Trace(data=C4[:, indaz], header=str_stats)
-
-        # Put all treaces into stream
-        hstream = Stream(traces=[A, B1, B2, C1, C2])
-        azim = indaz*daz
-        var = [C0var, C1var, C2var, C3var, C4var]
-
-        self.hstream = hstream
-        self.azim = azim
-        self.var = var
-
-        t1 = time.time()
-        print("Elapsed time ", t1-t0)
-
-    def dcomp_find_azim(self, xmin=None, xmax=None):
-        """
-        Method to decompose radial and transverse receiver function
-        streams into back-azimuth harmonics and determine the main
-        orientation ``azim``, obtained by minimizing the B1 component
-        between ``xmin`` and ``xmax`` (i.e., time or depth).
-
-        Parameters
-        ----------
-        xmin : float
-            Minimum x axis value over which to calculate ``azim``
-        xmax : float
-            Maximum x axis value over which to calculate ``azim``
+        use_numba : bool
+            Use ``numba`` just-in-time compiler to increase the processing speed, default to ``False``
 
         Attributes
         ----------
@@ -326,6 +160,168 @@ class Harmonics(object):
         # Copy stream stats
         str_stats = self.radialRF[0].stats
 
+        if use_numba == False:
+            # Initialize work arrays
+            C0 = np.zeros((nz, naz))
+            C1 = np.zeros((nz, naz))
+            C2 = np.zeros((nz, naz))
+            C3 = np.zeros((nz, naz))
+            C4 = np.zeros((nz, naz))
+            # Loop over each depth step
+            for iz in range(nz):
+
+                # Build matrices OBS and H for each azimuth
+                for iaz in range(naz):
+
+                    # Initialize work arrays
+                    OBS = np.zeros(2*nbin)
+                    H = np.zeros((2*nbin, 5))
+
+                    azim = iaz*daz
+
+                    # Radial component
+                    for irow, trace in enumerate(self.radialRF):
+
+                        baz = trace.stats.baz
+                        OBS[irow] = trace.data[iz]
+                        H[irow, 0] = 1.0
+                        H[irow, 1] = np.cos(deg2rad*(baz-azim))
+                        H[irow, 2] = np.sin(deg2rad*(baz-azim))
+                        H[irow, 3] = np.cos(2.*deg2rad*(baz-azim))
+                        H[irow, 4] = np.sin(2.*deg2rad*(baz-azim))
+
+                    shift = 90.
+
+                    # Transverse component
+                    for irow, trace in enumerate(self.transvRF):
+
+                        baz = trace.stats.baz
+                        OBS[irow+nbin] = trace.data[iz]
+                        H[irow+nbin, 0] = 0.0
+                        H[irow+nbin, 1] = np.cos(deg2rad*(baz+shift-azim))
+                        H[irow+nbin, 2] = np.sin(deg2rad*(baz+shift-azim))
+                        H[irow+nbin, 3] = np.cos(2.*deg2rad*(baz+shift/2.0-azim))
+                        H[irow+nbin, 4] = np.sin(2.*deg2rad*(baz+shift/2.0-azim))
+
+                    # Solve system of equations with truncated SVD
+                    u, s, v = np.linalg.svd(H)
+                    s[s < 0.001] = 0.
+                    CC = np.linalg.solve(s[:, None] * v, u.T.dot(OBS)[:5])
+
+                    # Fill up arrays
+                    C0[iz, iaz] = np.float(CC[0])
+                    C1[iz, iaz] = np.float(CC[1])
+                    C2[iz, iaz] = np.float(CC[2])
+                    C3[iz, iaz] = np.float(CC[3])
+                    C4[iz, iaz] = np.float(CC[4])
+
+            # Minimize variance of third component over specific depth range to
+            # find azim
+            C1var = np.zeros(naz)
+            for iaz in range(naz):
+                C1var[iaz] = np.sqrt(np.mean(np.square(C1[indmin:indmax, iaz])))
+            indaz = np.argmin(C1var)
+
+            C0var = np.sqrt(np.mean(np.square(C0[indmin:indmax, indaz])))
+            C1var = np.sqrt(np.mean(np.square(C1[indmin:indmax, indaz])))
+            C2var = np.sqrt(np.mean(np.square(C2[indmin:indmax, indaz])))
+            C3var = np.sqrt(np.mean(np.square(C3[indmin:indmax, indaz])))
+            C4var = np.sqrt(np.mean(np.square(C4[indmin:indmax, indaz])))
+
+        elif use_numba == True:
+            # convert stream objects to numpy array
+            baz_arr = np.array([trace0.stats.baz for trace0 in self.radialRF])
+            radialRF_arr = np.array([trace0.data for trace0 in self.radialRF])
+            transvRF_arr = np.array([trace0.data for trace0 in self.transvRF])
+            # run calculation using numba
+            with ProgressBar(total=len(self.radialRF[0].data), ascii=" #") as progress:
+                C0,C1,C2,C3,C4,C0var,C1var,C2var,C3var,C4var,indaz = \
+                self._dcomp_calculate_harmonics_isolated(
+                    nbin=nbin,
+                    nz=nz,
+                    indmin=indmin,
+                    indmax=indmax,
+                    baz_arr=baz_arr,
+                    radialRF_arr=radialRF_arr,
+                    transvRF_arr=transvRF_arr,
+                    progress_hook=progress
+                )
+
+        # Put back into traces
+        A = Trace(data=C0[:, indaz], header=str_stats)
+        B1 = Trace(data=C1[:, indaz], header=str_stats)
+        B2 = Trace(data=C2[:, indaz], header=str_stats)
+        C1 = Trace(data=C3[:, indaz], header=str_stats)
+        C2 = Trace(data=C4[:, indaz], header=str_stats)
+
+        # Put all treaces into stream
+        self.hstream = Stream(traces=[A, B1, B2, C1, C2])
+        self.azim = indaz*daz
+        self.var = [C0var, C1var, C2var, C3var, C4var]
+
+        t1 = time.time()
+        print("Elapsed time ", t1-t0)
+
+    @staticmethod
+    @numba.jit(nopython=True, nogil=True)
+    def _dcomp_calculate_harmonics_isolated(nbin=None, nz=None, baz_arr=None, \
+        radialRF_arr=None, transvRF_arr=None, indmin=None, indmax=None, progress_hook=None):
+        """
+        Method to decompose radial and transverse receiver function
+        array into back-azimuth harmonics. This static method is isolated from
+        ``decomp_find_azim`` to accomodate ``numba`` support that requires ```numpy```-like objects
+        when compiling to machine code.
+
+        Parameters
+        ----------
+        nbin : integer
+            Number of receiver function traces
+        nz : integer
+            Number of receiver function trace's points, corresponding to depth or time
+        indmax : integer
+            Index of maximum depth
+        indmin : integer
+            Index of minimum depth
+        baz_arr : :class:`~numpy.array`
+            Array containing each receiver function's back-azimuth
+        radialRF : :class:`~numpy.ndarray`
+            Array containing radial receiver functions
+        transvRF : :class:`~numpy.ndarray`
+            Array containing transversal receiver functions
+        progress_hook : :class:`~numba_progress.ProgressBar`
+            Progressbar hook to integrate ``numba_progress``
+
+        Attributes
+        ----------
+        C0 : :class:`~numpy.ndarray`
+            Array of C0 harmonic
+        C1 : :class:`~numpy.ndarray`
+            Array of C1 harmonic
+        C2 : :class:`~numpy.ndarray`
+            Array of C2 harmonic
+        C3 : :class:`~numpy.ndarray`
+            Array of C3 harmonic
+        C4 : :class:`~numpy.ndarray`
+            Array of C4 harmonic
+        C0var : :class:`~numpy.ndarray`
+            Array of C0 harmonic variance
+        C1var : :class:`~numpy.ndarray`
+            Array of C1 harmonic variance
+        C2var : :class:`~numpy.ndarray`
+            Array of C2 harmonic variance
+        C3var : :class:`~numpy.ndarray`
+            Array of C3 harmonic variance
+        C4var : :class:`~numpy.ndarray`
+            Array of C4 harmonic variance
+        indaz : integer
+            Index of minimum ``C1Var``
+        """
+
+        # Some integers
+        naz = 180
+        daz = np.float(360/naz)
+        deg2rad = np.pi/180.
+
         # Initialize work arrays
         C0 = np.zeros((nz, naz))
         C1 = np.zeros((nz, naz))
@@ -346,10 +342,10 @@ class Harmonics(object):
                 azim = iaz*daz
 
                 # Radial component
-                for irow, trace in enumerate(self.radialRF):
+                for irow, dataR, baz in zip(range(len(radialRF_arr)),radialRF_arr,baz_arr):
 
-                    baz = trace.stats.baz
-                    OBS[irow] = trace.data[iz]
+                    baz = baz
+                    OBS[irow] = dataR[iz]
                     H[irow, 0] = 1.0
                     H[irow, 1] = np.cos(deg2rad*(baz-azim))
                     H[irow, 2] = np.sin(deg2rad*(baz-azim))
@@ -359,10 +355,10 @@ class Harmonics(object):
                 shift = 90.
 
                 # Transverse component
-                for irow, trace in enumerate(self.transvRF):
+                for irow, dataT, baz in zip(range(len(transvRF_arr)),transvRF_arr,baz_arr):
 
-                    baz = trace.stats.baz
-                    OBS[irow+nbin] = trace.data[iz]
+                    baz = baz
+                    OBS[irow+nbin] = dataT[iz]
                     H[irow+nbin, 0] = 0.0
                     H[irow+nbin, 1] = np.cos(deg2rad*(baz+shift-azim))
                     H[irow+nbin, 2] = np.sin(deg2rad*(baz+shift-azim))
@@ -372,7 +368,7 @@ class Harmonics(object):
                 # Solve system of equations with truncated SVD
                 u, s, v = np.linalg.svd(H)
                 s[s < 0.001] = 0.
-                CC = np.linalg.solve(s[:, None] * v, u.T.dot(OBS)[:5])
+                CC = np.linalg.solve(s.reshape(s.shape[0],1) * v, u.T.dot(OBS)[:5])
 
                 # Fill up arrays
                 C0[iz, iaz] = np.float(CC[0])
@@ -380,6 +376,8 @@ class Harmonics(object):
                 C2[iz, iaz] = np.float(CC[2])
                 C3[iz, iaz] = np.float(CC[3])
                 C4[iz, iaz] = np.float(CC[4])
+
+            progress_hook.update(1)
 
         # Minimize variance of third component over specific depth range to
         # find azim
@@ -394,20 +392,7 @@ class Harmonics(object):
         C3var = np.sqrt(np.mean(np.square(C3[indmin:indmax, indaz])))
         C4var = np.sqrt(np.mean(np.square(C4[indmin:indmax, indaz])))
 
-        # Put back into traces
-        A = Trace(data=C0[:, indaz], header=str_stats)
-        B1 = Trace(data=C1[:, indaz], header=str_stats)
-        B2 = Trace(data=C2[:, indaz], header=str_stats)
-        C1 = Trace(data=C3[:, indaz], header=str_stats)
-        C2 = Trace(data=C4[:, indaz], header=str_stats)
-
-        # Put all treaces into stream
-        self.hstream = Stream(traces=[A, B1, B2, C1, C2])
-        self.azim = indaz*daz
-        self.var = [C0var, C1var, C2var, C3var, C4var]
-
-        t1 = time.time()
-        print("Elapsed time ", t1-t0)
+        return C0,C1,C2,C3,C4,C0var,C1var,C2var,C3var,C4var,indaz
 
     def dcomp_fix_azim(self, azim=None):
         """
@@ -503,7 +488,7 @@ class Harmonics(object):
         # Put all traces into stream
         self.hstream = Stream(traces=[A, B1, B2, C1, C2])
 
-    def forward(self, baz_list=None):
+    def forward(self, baz_arr=None):
         """
         Method to forward calculate radial and transverse component
         receiver functions given the 5 pre-determined harmonics and
@@ -513,7 +498,7 @@ class Harmonics(object):
 
         Parameters
         ----------
-        baz_list : list
+        baz_arr : list
             List of back-azimuth directions over which to calculate
             the receiver functions. If no list is specified, the method
             will use the same back-azimuths as those in the original
@@ -532,12 +517,12 @@ class Harmonics(object):
         if not hasattr(self, 'hstream'):
             raise(Exception("Decomposition has not been performed yet"))
 
-        if not baz_list:
+        if not baz_arr:
             print("Warning: no BAZ specified - using all baz from " +
                   "stored streams")
-            baz_list = [tr.stats.baz for tr in self.radialRF]
-        if not isinstance(baz_list, list):
-            baz_list = [baz_list]
+            baz_arr = [tr.stats.baz for tr in self.radialRF]
+        if not isinstance(baz_arr, list):
+            baz_arr = [baz_arr]
 
         # Some constants
         nz = len(self.hstream[0].data)
@@ -547,7 +532,7 @@ class Harmonics(object):
         self.radial_forward = Stream()
         self.transv_forward = Stream()
 
-        for baz in baz_list:
+        for baz in baz_arr:
             trR = Trace(header=self.hstream[0].stats)
             trT = Trace(header=self.hstream[0].stats)
 

--- a/rfpy/harmonics.py
+++ b/rfpy/harmonics.py
@@ -109,9 +109,9 @@ class Harmonics(object):
         self.xmax = xmax
 
     @staticmethod
-    @numba.jit(nopython=True)
+    @numba.jit(nopython=True, nogil=True)
     def _dcomp_find_azim_numba(
-        progress_proxy,
+        progress_proxy=None,
         xmin=None, xmax=None,
         nbin=None, nz=None, delta=None,
         baz_list=None,
@@ -143,8 +143,7 @@ class Harmonics(object):
 
         """
 
-        print()
-        print('Decomposing receiver functions into baz harmonics')
+        
 
         # Some integers
         nbin = nbin
@@ -230,6 +229,10 @@ class Harmonics(object):
         return C0,C1,C2,C3,C4,C0var,C1var,C2var,C3var,C4var,indaz,daz
 
     def dcomp_find_azim_numba(self, xmin=None, xmax=None):
+
+        print()
+        print('Decomposing receiver functions into baz harmonics')
+
         import time
         t0 = time.time()
 
@@ -242,7 +245,7 @@ class Harmonics(object):
         baz_list = np.array([trace0.stats.baz for trace0 in self.radialRF])
         dataR_list = np.array([trace0.data for trace0 in self.radialRF])
         dataT_list = np.array([trace0.data for trace0 in self.transvRF])
-        with ProgressBar(total=len(self.radialRF[0].data)) as progress:
+        with ProgressBar(total=len(self.radialRF[0].data), ascii=" #") as progress:
             C0,C1,C2,C3,C4,C0var,C1var,C2var,C3var,C4var,indaz,daz = self._dcomp_find_azim_numba(
                 xmin=xmin, xmax=xmax,
                 nbin=len(self.radialRF),

--- a/rfpy/scripts/rfpy_harmonics.py
+++ b/rfpy/scripts/rfpy_harmonics.py
@@ -88,14 +88,6 @@ def get_harmonics_arguments(argv=None):
         "Default behaviour uses short key form (NET.STN) for the folder " +
         "names, regardless of the key type of the database."
     )
-    parser.add_argument(
-        "-UN", "--use-numba",
-        action="store_true",
-        dest="use_numba",
-        default=False,
-        help="Use numba jit on calculation [Default False]"
-    )
-
 
     # Event Selection Criteria
     TimeGroup = parser.add_argument_group(
@@ -217,6 +209,13 @@ def get_harmonics_arguments(argv=None):
         default=False,
         help="Set this option to save the Harmonics object " +
         "to a pickled file. [Default does not save object]")
+    HarmonicGroup.add_argument(
+        "--use-numba",
+        action="store_true",
+        dest="use_numba",
+        default=False,
+        help="Use numba jit to increase processing speed [Default does not use numba]"
+    )
 
     PlotGroup = parser.add_argument_group(
         title='Settings for plotting results',
@@ -510,8 +509,9 @@ def main():
 
         # Stack with or without dip
         if args.find_azim:
+            # Check if the process use numba
             if args.use_numba:
-                harmonics.dcomp_find_azim_numba(xmin=args.trange[0], xmax=args.trange[1])
+                harmonics.dcomp_find_azim(xmin=args.trange[0], xmax=args.trange[1], use_numba=True)
             else:
                 harmonics.dcomp_find_azim(xmin=args.trange[0], xmax=args.trange[1])
 

--- a/rfpy/scripts/rfpy_harmonics.py
+++ b/rfpy/scripts/rfpy_harmonics.py
@@ -91,7 +91,7 @@ def get_harmonics_arguments(argv=None):
     parser.add_argument(
         "-UN", "--use-numba",
         action="store_true",
-        dest="unumba",
+        dest="use_numba",
         default=False,
         help="Use numba jit on calculation [Default False]"
     )
@@ -510,45 +510,10 @@ def main():
 
         # Stack with or without dip
         if args.find_azim:
-            import time
-            t0=time.time()
-            
-            if args.unumba:
-                from obspy.core import Trace
-                str_stats = harmonics.radialRF[0].stats
-                baz_list = np.array([trace0.stats.baz for trace0 in harmonics.radialRF])
-                dataR_list = np.array([trace0.data for trace0 in harmonics.radialRF])
-                dataT_list = np.array([trace0.data for trace0 in harmonics.transvRF])
-                C0,C1,C2,C3,C4,C0var,C1var,C2var,C3var,C4var,indaz,daz = harmonics.dcomp_find_azim_numba(
-                    xmin=args.trange[0], xmax=args.trange[1],
-                    nbin=len(harmonics.radialRF),
-                    nz=len(harmonics.radialRF[0].data),
-                    delta=harmonics.radialRF[0].stats.delta,
-                    baz_list=baz_list,
-                    dataR_list=dataR_list,
-                    dataT_list=dataT_list,
-
-                )
-                # Put back into traces
-                A = Trace(data=C0[:, indaz], header=str_stats)
-                B1 = Trace(data=C1[:, indaz], header=str_stats)
-                B2 = Trace(data=C2[:, indaz], header=str_stats)
-                C1 = Trace(data=C3[:, indaz], header=str_stats)
-                C2 = Trace(data=C4[:, indaz], header=str_stats)
-
-                # Put all treaces into stream
-                hstream = Stream(traces=[A, B1, B2, C1, C2])
-                azim = indaz*daz
-                var = [C0var, C1var, C2var, C3var, C4var]
-
-                harmonics.hstream = hstream
-                harmonics.azim = azim
-                harmonics.var = var
+            if args.use_numba:
+                harmonics.dcomp_find_azim_numba(xmin=args.trange[0], xmax=args.trange[1])
             else:
                 harmonics.dcomp_find_azim(xmin=args.trange[0], xmax=args.trange[1])
-
-            t1=time.time()
-            print("elapsed time ",t1-t0)
 
             print("Optimal azimuth for trange between " +
                   str(args.trange[0])+" and "+str(args.trange[1]) +

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
          'Programming Language :: Python :: 3.7',
          'Programming Language :: Python :: 3.8',
          'Programming Language :: Python :: 3.9'],
-    install_requires=['numpy', 'obspy', 'stdb>=0.2.0'],
+    install_requires=['numpy', 'numba', 'obspy', 'stdb>=0.2.0'],
     python_requires='>=3.6',
     packages=setuptools.find_packages(),
     entry_points={'console_scripts':[

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
          'Programming Language :: Python :: 3.7',
          'Programming Language :: Python :: 3.8',
          'Programming Language :: Python :: 3.9'],
-    install_requires=['numpy', 'numba', 'obspy', 'stdb>=0.2.0'],
+    install_requires=['numpy','obspy', 'stdb>=0.2.0', 'numba', 'numba_progress'],
     python_requires='>=3.6',
     packages=setuptools.find_packages(),
     entry_points={'console_scripts':[


### PR DESCRIPTION
Hi! Thank you very much for the code, I use it heavily on my thesis.

As mentioned in #27 which one of the todo list items is to convert the code to low level language (FORTRAN) to increase the performance, here I provide a [`numba`](https://numba.pydata.org)-optimized code  for `rfpy.harmonics`. `numba` translates Python functions to optimized machine code at runtime, it can be an alternative to performance optimization without rewriting the code to lower level language. 

I tested `rfpy_harmonics` and created a simple performance comparison by running the script for station **MMPY** for 9 different scenarios depending on the number of receiver functions (**nrf**), each of the scenario is executed based on two cases: with or without numba. 

## The device and environment for testing:
ROG Zephyrus G14 GA401QH_GA401QH
AMD Ryzen 7 5800HS with Radeon Graphics (16 CPUs), ~3.2GHz
8192MB RAM
Ubuntu 18.04 WSL2, Windows 11
Python 3.8.13

## The input parameters and the result:

### Table:
|station   |start     |end|trange           |nrf               |time_without_numba|time_with_numba   |
|----------|----------|---|-----------------|------------------|------------------|------------------|
|MMPY      |2017-01-01|2018-03-30|2-10             |137               |691.202392578125  |47.04966640472412 |
|MMPY      |2017-01-01|2017-11-06|2-10             |120               |630.3968324661255 |42.97214984893799 |
|MMPY      |2017-01-01|2017-09-23|2-10             |100               |537.779358625412  |33.96166014671326 |
|MMPY      |2017-01-01|2017-08-10|2-10             |80                |420.6219515800476 |25.681000471115112|
|MMPY      |2017-01-01|2017-07-14|2-10             |60                |314.8274037837982 |21.694521188735962|
|MMPY      |2017-01-01|2017-06-15|2-10             |41                |91.12138342857361 |8.571951150894165 |
|MMPY      |2017-01-01|2017-05-15|2-10             |30                |68.21855211257935 |6.957925796508789 |
|MMPY      |2017-01-01|2017-04-09|2-10             |21                |52.25753951072693 |5.868242502212524 |
|MMPY      |2017-01-01|2017-02-23|2-10             |11                |32.92144703865051 |4.929212331771851 |


### Graph:  
![test_numba_result](https://user-images.githubusercontent.com/48075471/175800520-5be4e37c-8fd1-4051-8dd6-9446d13d992e.png)

As shown on the table and graph, `numba` can significantly increase the performance.

## Changes
1. Added `_dcomp_calculate_harmonics_isolated` static method to isolate harmonics calculation based on `numba`, `obspy.Stream` object in this function is converted to `numpy.array` to accomodate `numba`
2. Added `use_numba` as argument for `rfpy.harmonics.Harmonic.dcomp_find_azim`, when this argument is True then the processing will be executed by `numba`
3. Added progressbar when processing is running using `tqdm` and `numba_progressbar`
4. Added `--use-numba` argument for `rfpy_harmonics`
5. Added `numba` and `numba_progressbar` in `setup.py`
6. Added documentation in `rfpy.rst` and `tutorial.rst`

## Notes
1. Because of the current behavior of `numba` as mentioned [here](https://github.com/numba/numba/issues/5551), canceling processing with CTRL+C is currently not supported when using `--use-numba`. Actually I have provided the solution on branch `harmonics-numba-sigint` but it requires GCC (Linux) or MSVC (Windows) to work.
2. The returned azimuth can be 180 degrees shifted compared to no numba because of the floating point behavior of `numba` as mentioned [here](https://numba.discourse.group/t/floating-point-pitfalls/405) and [here](https://numba.pydata.org/numba-doc/latest/reference/fpsemantics.html). For example, when running the first scenario on the table (137 nrf), the variances of C1 for index 83 and 173:
- with numba: 0.000890815608024939**4** and 0.000890815608024939**7**
- without numba: 0.000890815608024939**5** and 0.000890815608024939**5**
3. `numba` will a little bit slower in the first run because of compilation

## Screenshots
![linux_ss](https://user-images.githubusercontent.com/48075471/175801305-5faea881-16bf-414d-a572-70ed7288d7b4.png)
![windows_ss](https://user-images.githubusercontent.com/48075471/175801309-20215914-3387-4710-9e2f-4d04d1ccf1f2.png)

