### PR TITLE
Addition of a deconvolution method

### DIFF
--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -153,8 +153,8 @@ Usage
       Parameters for deconvolution
 
       --method METHOD       Specify the deconvolution method. Available methods
-                            include 'wiener', 'water' and 'multitaper'. [Default
-                            'wiener']
+                            include 'wiener', 'water', 'multitaper', and 
+                            'wiener_audet_bssa2010'. [Default 'wiener']
       --gfilt GFILT         Specify the Gaussian filter width in Hz. [Default
                             None]
       --wlevel WLEVEL       Specify the water level, used in the 'water' method.
@@ -240,8 +240,8 @@ Usage
       Parameters for deconvolution
 
       --method METHOD      Specify the deconvolution method. Available methods
-                           include 'wiener', 'water' and 'multitaper'. [Default
-                           'wiener']
+                           include 'wiener', 'water', 'multitaper' and 
+                           'wiener_audet_bssa2010'. [Default 'wiener']
       --gfilt GFILT        Specify the Gaussian filter width in Hz. [Default None]
       --wlevel WLEVEL      Specify the water level, used in the 'water' method.
                            [Default 0.01]
@@ -262,7 +262,7 @@ Usage
 
 .. code-block::
 
-    $ rfpy_recalc -h
+    $ rfpy_plot -h
 
     #################################################
     #        __                        _       _    #

--- a/rfpy/rfdata.py
+++ b/rfpy/rfdata.py
@@ -89,6 +89,9 @@ class Meta(object):
         if self.dep is not None:
             if self.dep > 1000.:
                 self.dep = self.dep/1000.
+            if self.dep < 0.:
+                # Some events have negative depths in km
+                self.dep = np.abs(self.dep)
         else:
             self.dep = 10.
 
@@ -647,7 +650,6 @@ class RFData(object):
             Stream containing the receiver function traces
 
         """
-
         if not self.meta.accept:
             return
 
@@ -669,13 +671,12 @@ class RFData(object):
             gauss[nft21:] = np.flip(gauss[1:nft21-1])
             return gauss
 
-        def _decon(parent, daughter1, daughter2, noise, nn, method):
-
+        def _decon(parent, daughter1, daughter2, noise_parent, noise_daughter1, nn, method):
             # Get length, zero padding parameters and frequencies
             dt = parent.stats.delta
 
             # Wiener or Water level deconvolution
-            if method == 'wiener' or method == 'water':
+            if method == 'wiener' or method == 'water' or method == "wiener_audet_bssa2010":
 
                 # npad = _npow2(nn*2)
                 npad = nn
@@ -685,17 +686,23 @@ class RFData(object):
                 Fp = np.fft.fft(parent.data, n=npad)
                 Fd1 = np.fft.fft(daughter1.data, n=npad)
                 Fd2 = np.fft.fft(daughter2.data, n=npad)
-                Fn = np.fft.fft(noise.data, n=npad)
+                Fpn = np.fft.fft(noise_parent.data, n=npad)
+                Fd1n = np.fft.fft(noise_daughter1.data, n=npad)
 
                 # Auto and cross spectra
                 Spp = np.real(Fp*np.conjugate(Fp))
                 Sd1p = Fd1*np.conjugate(Fp)
                 Sd2p = Fd2*np.conjugate(Fp)
-                Snn = np.real(Fn*np.conjugate(Fn))
+                Snpp = np.real(Fpn*np.conjugate(Fpn))
+                Snd1d1 = np.real(Fd1n*np.conjugate(Fd1n))
+                Snpd1 = np.abs(Fd1n*np.conjugate(Fpn))
 
                 # Final processing depends on method
                 if method == 'wiener':
-                    Sdenom = Spp + Snn
+                    Sdenom = Spp + Snpp
+                # Wiener ad-hoc deconvolution in Audet 2010 - BSSA
+                elif method == "wiener_audet_bssa2010":         
+                    Sdenom = Spp + 0.25*Snpp + 0.25*Snd1d1 + 0.5*Snpd1
                 elif method == 'water':
                     phi = np.amax(Spp)*wlevel
                     Sdenom = Spp
@@ -712,11 +719,11 @@ class RFData(object):
                         [tr.stats.npts for tr in [parent,
                                                   daughter1,
                                                   daughter2,
-                                                  noise]], npad):
+                                                  noise_parent]], npad):
                     parent.data = _pad(parent.data, npad)
                     daughter1.data = _pad(daughter1.data, npad)
                     daughter2.data = _pad(daughter2.data, npad)
-                    noise.data = _pad(noise.data, npad)
+                    noise_parent.data = _pad(noise_parent.data, npad)
 
                 freqs = np.fft.fftfreq(npad, d=dt)
 
@@ -732,7 +739,7 @@ class RFData(object):
                 Fd2 = np.fft.fft(np.multiply(tapers.transpose(),
                                              daughter2.data))
                 Fn = np.fft.fft(np.multiply(tapers.transpose(),
-                                            noise.data))
+                                            noise_parent.data))
 
                 # Auto and cross spectra
                 Spp = np.sum(np.real(Fp*np.conjugate(Fp)), axis=0)
@@ -848,10 +855,10 @@ class RFData(object):
 
         # Deconvolve
         if phase == 'P' or 'PP':
-            rfL, rfQ, rfT = _decon(trL, trQ, trT, trNl, nn, method)
+            rfL, rfQ, rfT = _decon(trL, trQ, trT, trNl, trNq, nn, method)
 
         elif phase == 'S' or 'SKS':
-            rfQ, rfL, rfT = _decon(trQ, trL, trT, trNq, nn, method)
+            rfQ, rfL, rfT = _decon(trQ, trL, trT, trNq, trNl, nn, method)
 
         # Update stats of streams
         rfL.stats.channel = 'RF' + self.meta.align[0]

--- a/rfpy/scripts/rfpy_calc.py
+++ b/rfpy/scripts/rfpy_calc.py
@@ -484,10 +484,11 @@ def get_calc_arguments(argv=None):
         print("SNR window > data window. Defaulting to data " +
               "window minus 10 sec.")
 
-    if args.method not in ['wiener', 'water', 'multitaper']:
+    if args.method not in ['wiener', 'water', 'multitaper', \
+                           'wiener_audet_bssa2010']:
         parser.error(
             "Error: 'method' should be either 'wiener', 'water' or " +
-            "'multitaper'")
+            "'multitaper', or 'wiener_audet_bssa2010'")
 
     return args
 
@@ -655,7 +656,7 @@ def main():
                 print("|   {0:>2s}.{1:5s}: {2:6d}".format(
                     sta.network, sta.station, len(stalcllist)) +
                     " files                      |")
-                #print(stalcllist[0:10])
+                print(stalcllist[0:10])
             else:
                 stalcllist = utils.list_local_data_stn(
                     lcldrs=args.localdata, sta=sta.station, dtype=args.dtype)

--- a/rfpy/scripts/rfpy_recalc.py
+++ b/rfpy/scripts/rfpy_recalc.py
@@ -224,10 +224,11 @@ def get_recalc_arguments(argv=None):
             "Error: Incorrect alignment specifier. Should be " +
             "either 'ZRT', 'LQT', or 'PVH'.")
 
-    if args.method not in ['wiener', 'water', 'multitaper']:
+    if args.method not in ['wiener', 'water', 'multitaper',\
+                           'wiener_audet_bssa2010']:
         parser.error(
-            "Error: 'method' should be either 'wiener', 'water' or " +
-            "'multitaper'")
+            "Error: 'method' should be either 'wiener', 'water',  " +
+            "'multitaper', or 'wiener_audet_bssa2010'")
 
     if args.pre_filt is not None:
         args.pre_filt = [float(val) for val in args.pre_filt.split(',')]


### PR DESCRIPTION
The changes include the addition of the modified Wiener deconvolution method described in Audet (2010) (https://doi.org/10.1785/0120090299) into rfdata class (rfdata.py), calculation (rfpy_calc.py) and recalculation (rfpy_recalc) scripts, and the relavant documentation. 