### PR TITLE
Save RFs and modify plotting options

### DIFF
--- a/docs/rfpy.rst
+++ b/docs/rfpy.rst
@@ -36,7 +36,6 @@ Also, the following packages are required:
 
 - `stdb <https://github.com/paudetseis/StDb>`_
 - `spectrum <https://github.com/cokelaer/spectrum>`_
-- `cartopy <https://scitools.org.uk/cartopy/docs/latest/>`_
 
 Other required packages (e.g., ``obspy``)
 will be automatically installed by ``stdb``.
@@ -49,7 +48,7 @@ where ``RfPy`` can be installed along with some of its dependencies.
 
 .. sourcecode:: bash
 
-   conda create -n rfpy python=3.9 obspy cartopy -c conda-forge
+   conda create -n rfpy python=3.10 obspy spectrum -c conda-forge
 
 Activate the newly created environment:
 
@@ -62,14 +61,13 @@ Install remaining dependencies using ``pip`` inside the ``rfpy`` environment:
 .. sourcecode:: bash
 
    pip install stdb
-   pip install spectrum
 
-Installing from Pypi
---------------------
+Installing from GitHub master branch
+------------------------------------
 
 .. sourcecode:: bash
 
-   pip install rfpy
+   pip install rfpy@git+https://github.com/paudetseis/rfpy
 
 Installing from source
 ----------------------

--- a/rfpy/__init__.py
+++ b/rfpy/__init__.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 __author__ = 'Pascal Audet'
 

--- a/rfpy/binning.py
+++ b/rfpy/binning.py
@@ -70,17 +70,20 @@ def bin(stream1, stream2=None, typ='baz', nbin=36+1, pws=False,
         raise(Exception("Type has to be 'baz' or 'slow' or 'dist'"))
 
     if typ == 'baz':
+        stat = [stream1[i].stats.baz for i in range(len(stream1))]
         bmin = 0
         bmax = 360
-        stat = [stream1[i].stats.baz for i in range(len(stream1))]
+        alt = np.mean([stream1[i].stats.slow for i in range(len(stream1))])
     elif typ == 'slow':
         stat = [stream1[i].stats.slow for i in range(len(stream1))]
         bmin = np.min(np.array(stat))
         bmax = np.max(np.array(stat))
+        alt = np.mean([stream1[i].stats.baz for i in range(len(stream1))])
     elif typ == 'dist':
         stat = [stream1[i].stats.gac for i in range(len(stream1))]
         bmin = np.min(np.array(stat))
         bmax = np.max(np.array(stat))
+        alt = np.mean([stream1[i].stats.baz for i in range(len(stream1))])
 
     # Define bins
     bins = np.linspace(bmin, bmax, nbin)
@@ -126,16 +129,16 @@ def bin(stream1, stream2=None, typ='baz', nbin=36+1, pws=False,
                     trace.stats.nbin = nb
                     if typ == 'baz':
                         trace.stats.baz = bins[i]
-                        trace.stats.slow = None
+                        trace.stats.slow = alt
                         trace.stats.nbin = nb
                     elif typ == 'slow': 
                         trace.stats.slow = bins[i]
-                        trace.stats.baz = None
+                        trace.stats.baz = alt
                         trace.stats.nbin = nb
                     elif typ == 'dist':
                         trace.stats.dist = bins[i]
                         trace.stats.slow = None
-                        trace.stats.baz = None
+                        trace.stats.baz = alt
                         trace.stats.nbin = nb
                     if not pws:
                         weight = np.ones(len(stream[0].data))

--- a/rfpy/plotting.py
+++ b/rfpy/plotting.py
@@ -390,8 +390,12 @@ def wiggle_bins(stream1, stream2=None, tr1=None, tr2=None,
             ax4.set_title('Transverse')
 
     if save:
-        plt.savefig('RF_PLOTS/' + stream1[0].stats.station +
-                    '.' + save, format=save.split('.')[-1])
+        if folder is not None:
+            plt.savefig(folder + '/' + stream1[0].stats.station +
+                        '.' + save, format=save.split('.')[-1], dpi=300)
+        else:
+            plt.savefig('RF_PLOTS/' + stream1[0].stats.station +
+                        '.' + save, format=save.split('.')[-1], dpi=300)
 
     if show:
         plt.show()

--- a/rfpy/scripts/rfpy_plot.py
+++ b/rfpy/scripts/rfpy_plot.py
@@ -192,14 +192,12 @@ def get_plot_arguments(argv=None):
         title='Plot Settings',
         description="Options for plot format")
     PlotGroup.add_argument(
-        "--scale",
-        action="store",
-        dest="scale",
-        default=None,
-        type=float,
-        help="Specify the scaling factor for the amplitude of the " +
-        "receiver functions in the wiggle plots. [Default 100. for " +
-        "a back-azimuth plot, 0.02 for a slowness plot]")
+        "--stack",
+        action="store_true",
+        dest="stacked",
+        default=False,
+        help="Set this option to plot a stack of all traces in top panel. " +
+        "[Default does not plot stacked traces]")
     PlotGroup.add_argument(
         "--normalize",
         action="store_true",
@@ -216,34 +214,30 @@ def get_plot_arguments(argv=None):
         help="Specify the time range for the x-axis (sec). Negative times " +
         "are allowed [Default 0., 30.]")
     PlotGroup.add_argument(
-        "--stacked",
-        action="store_true",
-        dest="stacked",
-        default=False,
-        help="Set this option to plot a stack of all traces in top panel. " +
-        "[Default does not plot stacked traces]")
-    PlotGroup.add_argument(
-        "--save",
-        action="store_true",
-        dest="saveplot",
-        default=False,
-        help="Set this option if you wish to save the figure. [Default " +
-        "does not save figure]")
-    PlotGroup.add_argument(
-        "--title",
+        "--save-fig",
         action="store",
-        dest="titleplot",
+        dest="figname",
         type=str,
-        default='',
-        help="Specify title of figure. [Default None]")
+        default=None,
+        help="Specify figure filename if you wish to save the figure. By " +
+        "default, the station name will be pre-appended to the file name and " +
+        "saved to 'RF_PLOTS' unless --save-rfs is set. Valid figure formats " +
+        "are 'png', 'jpg', 'eps', 'pdf'. [Default does not save figure]")
     PlotGroup.add_argument(
-        "--format",
+        "--save-rfs",
         action="store",
+        dest="rf_folder",
         type=str,
-        dest="form",
-        default="png",
-        help="Specify format of figure. Can be any one of the valid" +
-        "matplotlib formats: 'png', 'jpg', 'eps', 'pdf'. [Default 'png']")
+        default=None,
+        help="Specify folder name to save the plotted RFs. [Default does not " +
+        "save RFs]")
+    PlotGroup.add_argument(
+        "--hide-fig",
+        action="store_true",
+        dest="hide",
+        default=False,
+        help="Specify if you do not wish to show the figure upon " +
+        "execution. [Default shows the figure]")
     PlotGroup.add_argument(
         "--plot-event-dist",
         action="store_true",
@@ -314,6 +308,11 @@ def get_plot_arguments(argv=None):
             parser.error(
                 "Error: --trange should contain 2 " +
                 "comma-separated floats")
+
+    if args.figname is not None:
+        if args.figname.split('.')[-1] not in ['png', 'jpg', 'eps', 'pdf']:
+            parser.error(
+                "Error: Invalid figure extension. Choose among 'jpg', 'png', 'eps', 'pdf'")      
 
     # create station key list
     if len(args.stkeys) > 0:
@@ -498,8 +497,12 @@ def main():
                              freqmax=args.bp[1], corners=2,
                              zerophase=True)
 
-        if args.saveplot and not Path('RF_PLOTS').is_dir():
+        ##########
+        if (args.figname is not None) and (args.rf_folder is None) and (not Path('RF_PLOTS').is_dir()):
             Path('RF_PLOTS').mkdir(parents=True)
+        elif (args.rf_folder is not None) and (not Path(args.rf_folder).is_dir()):
+            Path(args.rf_folder).mkdir(parents=True)
+        ##########
 
         print('')
         print(datapath)
@@ -534,16 +537,6 @@ def main():
             tr2 = st_tmp[1]
             if args.norm:
                 # Find normalization constant
-                # st_tmp = binning.bin_all(rf_tmp[0], rf_tmp[1], pws=args.pws)
-                # tr1 = st_tmp[0]
-                # tr2 = st_tmp[1]
-                # tmp1 = tr1.data[(taxis > args.trange[0]) & (
-                #     taxis < args.trange[1])]
-                # tmp2 = tr2.data[(taxis > args.trange[0]) & (
-                #     taxis < args.trange[1])]
-                # normR = np.amax(np.abs(tmp1))
-                # normT = np.amax(np.abs(tmp2))
-                # norm = np.max([normR, normT])
                 tmp1 = np.array([tr.data[(taxis > args.trange[0]) & (
                     taxis < args.trange[1])] for tr in rf_tmp[0]])
                 tmp2 = np.array([tr.data[(taxis > args.trange[0]) & (
@@ -560,26 +553,43 @@ def main():
 
         # Now plot
         if args.nbaz:
-            plotting.wiggle_bins(rf_tmp[0], rf_tmp[1], tr1=tr1, tr2=tr2,
-                                 btyp='baz', scale=args.scale,
-                                 tmin=args.trange[0], tmax=args.trange[1],
-                                 norm=norm, save=args.saveplot,
-                                 title=args.titleplot, form=args.form)
+            plotting.wiggle_bins(
+                rf_tmp[0],
+                rf_tmp[1],
+                tr1=tr1,
+                tr2=tr2,
+                btyp='baz',
+                trange=args.trange,
+                norm=norm,
+                save=args.figname,
+                folder=args.rf_folder,
+                show=(not args.hide))
         elif args.nslow:
-            plotting.wiggle_bins(rf_tmp[0], rf_tmp[1], tr1=tr1, tr2=tr2,
-                                 btyp='slow', scale=args.scale,
-                                 tmin=args.trange[0], tmax=args.trange[1],
-                                 norm=norm, save=args.saveplot,
-                                 title=args.titleplot, form=args.form)
+            plotting.wiggle_bins(
+                rf_tmp[0],
+                rf_tmp[1],
+                tr1=tr1,
+                tr2=tr2,
+                btyp='slow',
+                trange=args.trange,
+                norm=norm,
+                save=args.figname,
+                folder=args.rf_folder,
+                show=(not args.hide))
 
-        # Update processed folders
-        procfold.append(stfld)
+        # Save RFs?
+        if args.rf_folder is not None:
+            print(args.__dict__)
+            [print(tr.stats.baz, tr.stats.slow) for tr in rf_tmp[0]]
+
 
         # Event distribution
         if args.plot_event_dist:
             plotting.event_dist(
-                rfRstream, phase=args.phase, save=args.saveplot,
-                title=args.titleplot, form=args.form)
+                rfRstream, phase=args.phase, save=args.figname)
+
+        # Update processed folders
+        procfold.append(stfld)
 
 
 if __name__ == "__main__":

--- a/rfpy/scripts/rfpy_plot.py
+++ b/rfpy/scripts/rfpy_plot.py
@@ -577,10 +577,26 @@ def main():
                 folder=args.rf_folder,
                 show=(not args.hide))
 
-        # Save RFs?
+        # Save RFs
         if args.rf_folder is not None:
-            print(args.__dict__)
-            [print(tr.stats.baz, tr.stats.slow) for tr in rf_tmp[0]]
+            import json 
+            import csv
+             
+            # Write the command-line arguments to a hidden JSON file 
+            with open(Path(args.rf_folder) / '.proc.json', 'w') as file: 
+                json.dump(args.__dict__, file) 
+
+            # Write baz and slow to .csv file
+            bb = [tr.stats.baz for tr in rf_tmp[0]]
+            ss = [tr.stats.slow for tr in rf_tmp[0]]
+            with open(
+                Path(args.rf_folder) / 'baz_slow.csv',
+                mode='w',
+                newline='') as file:
+                writer = csv.writer(file)
+                writer.writerow(['# BAZ', 'SLOW'])
+                for b, s in zip(bb, ss):
+                    writer.writerow([f"{b:.0f}", f"{s:.3f}"])
 
 
         # Event distribution


### PR DESCRIPTION
This PR adds new options for viewing and saving RFs using `ropy_plot`:
- The options `--stack` and `--normalize` are now untangled
- New options to specify the file name and folder for saving the figures
- If folder name is specified, the script also saves the RFs as SAC files and metadata
- arguments used in `rppy_plot` also saved as a hidden `.proc.json` file in save folder
- Removed plotting of geographic event distribution - to be fixed later